### PR TITLE
Make Dockerfile more cache-friendly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ FROM django
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY requirements /usr/src/app/requirements
-RUN pip install --no-cache-dir -r requirements/dev.txt
-
-COPY . /usr/src/app
-
 RUN apt-get update && apt-get install -y \
     bzip2 \
     fontconfig \
@@ -15,6 +10,11 @@ RUN apt-get update && apt-get install -y \
     libfreetype6-dev \
     nodejs npm \
   --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+COPY requirements /usr/src/app/requirements
+RUN pip install --no-cache-dir -r requirements/dev.txt
+
+COPY . /usr/src/app
 
 RUN ln -s /usr/bin/nodejs /usr/bin/node && \
     npm install && \


### PR DESCRIPTION
This way each change in application won't trigger downloading packages from APT.
