### PR TITLE
Upgrade Django to 1.9

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r common.txt
 
-Django==1.8.6  # blessed version of django
+Django>=1.9  # brand new version of django
 
 # Debugging packages
 ipython==4.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r common.txt
 
-Django>=1.9  # brand new version of django
+Django==1.9  # brand new version of django
 
 # Debugging packages
 ipython==4.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,3 @@
 -r common.txt
 
-Django>=1.9  # brand new version of django
+Django==1.9  # brand new version of django

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,3 @@
 -r common.txt
 
-Django==1.8.6  # blessed version of django
+Django>=1.9  # brand new version of django

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{18}, py34-django{18}
+envlist = py27-django{18,19}, py34-django{18,19}
 skipsdist = True
 
 [testenv]
@@ -8,5 +8,4 @@ setenv =
     DJANGO_SETTINGS_MODULE = bennedetto.settings.test
     PYTHONPATH = {toxinidir}
 deps =
-    django18: Django>=1.8, <1.9
     -rrequirements/test.txt


### PR DESCRIPTION
Here it goes, as suggested in #57.
Changed required version in both `dev` and `prod`.
Also... I think there is a typo in the tox file: `rrequirements/test.txt`. Should it be fixed here?
