### PR TITLE
add install-prod target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ superuser:
 	${manage} createsuperuser
 install-dev:
 	${install} -r requirements/dev.txt
+install-prod:
+	${install} -r requirements/prod.txt
 migrate:
 	${manage} migrate
 run:


### PR DESCRIPTION
Added `install-prod` target to the Makefile. There was already a `requirements/prod.txt` file, just no target.  
